### PR TITLE
Ajout des pages d'historique pour chaque capteur

### DIFF
--- a/Vue/historique.css
+++ b/Vue/historique.css
@@ -38,3 +38,18 @@
     background-color: #f3f3f3;
   }
   
+/* Formulaire de filtre */
+#filtre-form {
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+#filtre-form label {
+    font-weight: bold;
+}
+
+#filtre-form input[type="date"] {
+    padding: 5px;
+}

--- a/header.html
+++ b/header.html
@@ -14,9 +14,9 @@
       <img src="images/LOGOdbreeze.png" alt="Logo DBreeze">
     </a>
     <nav class="nav">
-      <a href="#">Accueil</a>
+      <a href="index.html">Accueil</a>
       <a href="#">Live</a>
-      <a href="#">Capteurs</a>
+      <a href="historique_sonore.html">Historique</a>
       <a href="#">Se déconnecter</a>
     </nav>
   </div>

--- a/historique_luminosite.html
+++ b/historique_luminosite.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Historique luminosité – DBreeze</title>
+  <link rel="stylesheet" href="Vue/style.css">
+  <link rel="stylesheet" href="Vue/historique.css">
+</head>
+<body>
+  <div id="header-placeholder"></div>
+
+  <main class="historique">
+    <div class="container">
+      <h2>Historique luminosité</h2>
+      <p>Choisissez une période pour visualiser la luminosité enregistrée.</p>
+
+      <form id="filtre-form">
+        <label for="start-date">Du :</label>
+        <input type="date" id="start-date" name="start" required>
+        <label for="end-date">au :</label>
+        <input type="date" id="end-date" name="end" required>
+        <button type="submit" class="btn">Filtrer</button>
+      </form>
+
+      <table class="historique-table" id="historique-table">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Luminosité max (lux)</th>
+            <th>Luminosité min (lux)</th>
+          </tr>
+        </thead>
+        <tbody id="historique-body">
+          <tr data-date="2025-06-10">
+            <td>2025-06-10</td>
+            <td>520</td>
+            <td>80</td>
+          </tr>
+          <tr data-date="2025-06-09">
+            <td>2025-06-09</td>
+            <td>500</td>
+            <td>75</td>
+          </tr>
+          <tr data-date="2025-06-08">
+            <td>2025-06-08</td>
+            <td>610</td>
+            <td>90</td>
+          </tr>
+          <tr data-date="2025-06-07">
+            <td>2025-06-07</td>
+            <td>480</td>
+            <td>70</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </main>
+
+  <div id="footer-placeholder"></div>
+
+  <script>
+    async function includeHTML(selector, url) {
+      const element = document.querySelector(selector);
+      const response = await fetch(url);
+      element.innerHTML = await response.text();
+    }
+    includeHTML("#header-placeholder", "header.html");
+    includeHTML("#footer-placeholder", "footer.html");
+
+    const form = document.getElementById('filtre-form');
+    const tbody = document.getElementById('historique-body');
+
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      const start = new Date(document.getElementById('start-date').value);
+      const end = new Date(document.getElementById('end-date').value);
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      rows.forEach(row => {
+        const date = new Date(row.dataset.date);
+        row.style.display = (date >= start && date <= end) ? '' : 'none';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/historique_sonore.html
+++ b/historique_sonore.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Historique sonore – DBreeze</title>
+  <link rel="stylesheet" href="Vue/style.css">
+  <link rel="stylesheet" href="Vue/historique.css">
+</head>
+<body>
+  <div id="header-placeholder"></div>
+
+  <main class="historique">
+    <div class="container">
+      <h2>Historique sonore</h2>
+      <p>Choisissez une période pour consulter les données enregistrées par le capteur sonore.</p>
+
+      <form id="filtre-form">
+        <label for="start-date">Du :</label>
+        <input type="date" id="start-date" name="start" required>
+        <label for="end-date">au :</label>
+        <input type="date" id="end-date" name="end" required>
+        <button type="submit" class="btn">Filtrer</button>
+      </form>
+
+      <table class="historique-table" id="historique-table">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Niveau max (dB)</th>
+            <th>Durée > 85 dB (min)</th>
+          </tr>
+        </thead>
+        <tbody id="historique-body">
+          <tr data-date="2025-06-10">
+            <td>2025-06-10</td>
+            <td>101.3 dB</td>
+            <td>42</td>
+          </tr>
+          <tr data-date="2025-06-09">
+            <td>2025-06-09</td>
+            <td>97.5 dB</td>
+            <td>37</td>
+          </tr>
+          <tr data-date="2025-06-08">
+            <td>2025-06-08</td>
+            <td>89.7 dB</td>
+            <td>15</td>
+          </tr>
+          <tr data-date="2025-06-07">
+            <td>2025-06-07</td>
+            <td>96.2 dB</td>
+            <td>29</td>
+          </tr>
+          <tr data-date="2025-06-06">
+            <td>2025-06-06</td>
+            <td>93.1 dB</td>
+            <td>21</td>
+          </tr>
+          <tr data-date="2025-06-05">
+            <td>2025-06-05</td>
+            <td>105.9 dB</td>
+            <td>65</td>
+          </tr>
+          <tr data-date="2025-06-04">
+            <td>2025-06-04</td>
+            <td>92.3 dB</td>
+            <td>9</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </main>
+
+  <div id="footer-placeholder"></div>
+
+  <script>
+    async function includeHTML(selector, url) {
+      const element = document.querySelector(selector);
+      const response = await fetch(url);
+      element.innerHTML = await response.text();
+    }
+    includeHTML("#header-placeholder", "header.html");
+    includeHTML("#footer-placeholder", "footer.html");
+
+    const form = document.getElementById('filtre-form');
+    const tbody = document.getElementById('historique-body');
+
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      const start = new Date(document.getElementById('start-date').value);
+      const end = new Date(document.getElementById('end-date').value);
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      rows.forEach(row => {
+        const date = new Date(row.dataset.date);
+        if (date >= start && date <= end) {
+          row.style.display = '';
+        } else {
+          row.style.display = 'none';
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/historique_temperature.html
+++ b/historique_temperature.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Historique température – DBreeze</title>
+  <link rel="stylesheet" href="Vue/style.css">
+  <link rel="stylesheet" href="Vue/historique.css">
+</head>
+<body>
+  <div id="header-placeholder"></div>
+
+  <main class="historique">
+    <div class="container">
+      <h2>Historique température</h2>
+      <p>Sélectionnez une période pour consulter les relevés de température.</p>
+
+      <form id="filtre-form">
+        <label for="start-date">Du :</label>
+        <input type="date" id="start-date" name="start" required>
+        <label for="end-date">au :</label>
+        <input type="date" id="end-date" name="end" required>
+        <button type="submit" class="btn">Filtrer</button>
+      </form>
+
+      <table class="historique-table" id="historique-table">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Température max (°C)</th>
+            <th>Température min (°C)</th>
+          </tr>
+        </thead>
+        <tbody id="historique-body">
+          <tr data-date="2025-06-10">
+            <td>2025-06-10</td>
+            <td>28.5</td>
+            <td>21.1</td>
+          </tr>
+          <tr data-date="2025-06-09">
+            <td>2025-06-09</td>
+            <td>27.8</td>
+            <td>20.0</td>
+          </tr>
+          <tr data-date="2025-06-08">
+            <td>2025-06-08</td>
+            <td>30.0</td>
+            <td>22.5</td>
+          </tr>
+          <tr data-date="2025-06-07">
+            <td>2025-06-07</td>
+            <td>26.2</td>
+            <td>19.9</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </main>
+
+  <div id="footer-placeholder"></div>
+
+  <script>
+    async function includeHTML(selector, url) {
+      const element = document.querySelector(selector);
+      const response = await fetch(url);
+      element.innerHTML = await response.text();
+    }
+    includeHTML("#header-placeholder", "header.html");
+    includeHTML("#footer-placeholder", "footer.html");
+
+    const form = document.getElementById('filtre-form');
+    const tbody = document.getElementById('historique-body');
+
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      const start = new Date(document.getElementById('start-date').value);
+      const end = new Date(document.getElementById('end-date').value);
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      rows.forEach(row => {
+        const date = new Date(row.dataset.date);
+        row.style.display = (date >= start && date <= end) ? '' : 'none';
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- utiliser le header/footer existants
- créer des pages d'historique pour les capteurs (sonore, température, luminosité)
- ajouter un formulaire de filtre par date pour chaque page
- mettre à jour le header avec un lien vers l'historique
- petite extension du CSS pour mettre en forme le formulaire

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684bf732b62083228fc8b300e1469e47